### PR TITLE
Make it clear that the parameter must be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ turf featureCollection module
 
 ### `turf.featurecollection(features)`
 
-Takes one or more Feature|Features and creates a FeatureCollection.
+Takes an array of one or more Feature|Features and creates a FeatureCollection.
 
 
 ### Parameters
 
-| parameter  | type    | description    |
-| ---------- | ------- | -------------- |
-| `features` | Feature | input features |
+| parameter  | type               | description    |
+| ---------- | ------------------ | -------------- |
+| `features` | Array\.\<Feature\> | input features |
 
 
 ### Example

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  *
  * @module turf/featurecollection
  * @category helper
- * @param {Feature} features input features
+ * @param {Feature[]} features input features
  * @returns {FeatureCollection} a FeatureCollection of input features
  * @example
  * var features = [


### PR DESCRIPTION
It's pretty clear from the code and knowing GeoJSON, but I've witnessed people passing a single Feature to this and failing. I tried to match the formatting from [turf-point](https://github.com/Turfjs/turf-point) but please let me know if I'm missing something.
